### PR TITLE
Remove summary placeholder

### DIFF
--- a/AQHub/realtime.html
+++ b/AQHub/realtime.html
@@ -289,7 +289,7 @@
                     <div class="row">
                         <div class="col-md-9 mr-auto">
                             <p><em class="pl-2">Last measurement: <span id="printTime"></span></em></p>
-                            <p class="pl-2">Most recent 24-hour average for <span id="loc">LOCATION</span>: <span id="24av">XX</span> µg/m3. This is <span class="comparison">ABOVE/BELOW</span> the 24-hour  National Ambient Air Quality Standard.</p>
+                            {{/*  <p class="pl-2">Most recent 24-hour average for <span id="loc">LOCATION</span>: <span id="24av">XX</span> µg/m3. This is <span class="comparison">ABOVE/BELOW</span> the 24-hour  National Ambient Air Quality Standard.</p>  */}}
                         </div>
 
                         <div class="col-md-3 ml-auto">


### PR DESCRIPTION
Removing the placeholder for summary information - I'd like to get this prototype launch-ready before working on additional features or major revisions, given some time constraints. 